### PR TITLE
ADD: export script batch file

### DIFF
--- a/shell_postgres/shell_console/backup_database.bat
+++ b/shell_postgres/shell_console/backup_database.bat
@@ -1,4 +1,5 @@
 @echo off
+chcp 65001 >nul
 setlocal enabledelayedexpansion
 
 REM Configuración

--- a/shell_postgres/shell_console/create_and_restore_database.bat
+++ b/shell_postgres/shell_console/create_and_restore_database.bat
@@ -1,4 +1,5 @@
 @echo off
+chcp 65001 >nul
 setlocal enabledelayedexpansion
 
 REM Configuración

--- a/shell_postgres/shell_console/create_user.bat
+++ b/shell_postgres/shell_console/create_user.bat
@@ -1,4 +1,5 @@
 @echo off
+chcp 65001 >nul
 setlocal enabledelayedexpansion
 
 set PGHOST=localhost

--- a/shell_postgres/shell_console/delete_database.bat
+++ b/shell_postgres/shell_console/delete_database.bat
@@ -1,4 +1,5 @@
 @echo off
+chcp 65001 >nul
 setlocal enabledelayedexpansion
 
 REM Configuración

--- a/shell_postgres/shell_console/export_script.bat
+++ b/shell_postgres/shell_console/export_script.bat
@@ -1,0 +1,23 @@
+@echo off
+setlocal enabledelayedexpansion
+
+REM Configuración
+set PGUSER=postgres
+set PGHOST=localhost
+set PGPORT=5432
+set DEFAULT_DB=mi_financiera_demo
+
+:mainMenu
+cls
+echo ****************************************
+echo *           Exportar Script            *
+echo ****************************************
+echo 1. Exportar en TXT
+echo 2. Exportar en CSV
+echo 0. Salir
+echo ****************************************
+set /p choice="Selecciona una opcion: "
+
+if "%choice%"=="1" call backup_database.bat
+if "%choice%"=="2" call restore_database.bat
+if "%choice%"=="0" goto :exitProgram

--- a/shell_postgres/shell_console/export_script.bat
+++ b/shell_postgres/shell_console/export_script.bat
@@ -1,4 +1,5 @@
 @echo off
+chcp 65001 >nul
 setlocal enabledelayedexpansion
 
 set DEFAULT_USER=postgres
@@ -88,9 +89,11 @@ if not exist "%EXPORT_DIR%" (
 set "EXPORT_FILE=%EXPORT_DIR%\!DATABASE!_!TABLE:.=_!_export_%EXPORT_DATE%.txt"
 
 psql -U %DEFAULT_USER% -d !DATABASE! -c "COPY %TABLE% TO STDOUT WITH (FORMAT TEXT, DELIMITER E'\t')" > %EXPORT_FILE%
+
 echo.
 echo Exportando datos de la tabla %TABLE% de la base de datos %DATABASE%...
 echo Archivo TEXT exportado con éxito en %EXPORT_DIR%.
+echo.
 
 pause
 goto :mainMenu
@@ -159,6 +162,7 @@ psql -U %DEFAULT_USER% -d !DATABASE! -c "COPY %TABLE% TO STDOUT WITH (FORMAT CSV
 echo.
 echo Exportando datos de la tabla %TABLE% de la base de datos %DATABASE%...
 echo Archivo CSV exportado correctamente en %EXPORT_DIR%.
+echo.
 
 pause
 goto :mainMenu
@@ -203,7 +207,7 @@ set "DATABASE=!db%dbchoice%!"
 
 echo.
 echo Listando tablas disponibles en la base de datos %DATABASE%...
-psql -U %PGUSER% -h %PGHOST% -p %PGPORT% -d %DATABASE% -t -c "SELECT tablename FROM pg_tables WHERE schemaname='public';" > temp_tables.txt
+psql -U %DEFAULT_USER% -h %PGHOST% -p %PGPORT% -d %DATABASE% -t -c "SELECT tablename FROM pg_tables WHERE schemaname='public';" > temp_tables.txt
 
 set count=0
 for /f "usebackq tokens=* delims=" %%a in ("temp_tables.txt") do (
@@ -238,7 +242,7 @@ if not exist "%EXPORT_DIR%" (
 )
 set "EXPORT_FILE=%EXPORT_DIR%\!TABLE!_export_%EXPORT_DATE%.json"
 
-psql -U %PGUSER% -h %PGHOST% -p %PGPORT% -d %DATABASE% -t -c "SELECT json_agg(row_to_json(t)) FROM (SELECT * FROM !TABLE!) t" > "!EXPORT_FILE!"
+psql -U %DEFAULT_USER% -h %PGHOST% -p %PGPORT% -d %DATABASE% -t -c "SELECT json_agg(row_to_json(t)) FROM (SELECT * FROM !TABLE!) t" > "!EXPORT_FILE!"
 
 echo.
 echo Exportando datos de la tabla %TABLE% de la base de datos %DATABASE%...
@@ -280,7 +284,7 @@ set "DATABASE=!db%dbchoice%!"
 
 echo.
 echo Listando tablas disponibles en la base de datos %DATABASE%...
-psql -U %PGUSER% -h %PGHOST% -p %PGPORT% -d %DATABASE% -t -c "SELECT tablename FROM pg_tables WHERE schemaname='public';" > temp_tables.txt
+psql -U %DEFAULT_USER% -h %PGHOST% -p %PGPORT% -d %DATABASE% -t -c "SELECT tablename FROM pg_tables WHERE schemaname='public';" > temp_tables.txt
 
 set count=0
 for /f "usebackq tokens=* delims=" %%a in ("temp_tables.txt") do (
@@ -318,7 +322,7 @@ set "EXPORT_FILE=%EXPORT_DIR%\!TABLE!_export_%EXPORT_DATE%.xml"
 
 echo ^<?xml version="1.0" encoding="UTF-8"?^> > "!EXPORT_FILE!"
 
-psql -U %PGUSER% -h %PGHOST% -p %PGPORT% -d %DATABASE% -q -A -t -c "SELECT COALESCE(xmlelement(name rows, xmlagg(xmlelement(name row, xmlforest(t.*)))), xmlelement(name rows)) FROM (SELECT * FROM !TABLE!) t;" >> "!EXPORT_FILE!"
+psql -U %DEFAULT_USER% -h %PGHOST% -p %PGPORT% -d %DATABASE% -q -A -t -c "SELECT COALESCE(xmlelement(name rows, xmlagg(xmlelement(name row, xmlforest(t.*)))), xmlelement(name rows)) FROM (SELECT * FROM !TABLE!) t;" >> "!EXPORT_FILE!"
 
 echo.
 echo Exportando datos de la tabla %TABLE% de la base de datos %DATABASE%...

--- a/shell_postgres/shell_console/export_script.bat
+++ b/shell_postgres/shell_console/export_script.bat
@@ -332,6 +332,6 @@ pause
 goto mainMenu
 
 :exitProgram
-echo Saliendo del programa...
+echo Regresando al menú principal...
 endlocal
 exit /b

--- a/shell_postgres/shell_console/export_script.bat
+++ b/shell_postgres/shell_console/export_script.bat
@@ -49,7 +49,10 @@ if %count%==0 (
     pause
     goto :mainMenu
 )
-set /p dbchoice="Selecciona una base de datos: "
+set /p dbchoice="Selecciona una base de datos [por defecto: %DEFAULT_DB%]: "
+if "%dbchoice%"=="" (
+    set dbname=%DEFAULT_DB%
+) 
 set "DATABASE=!db%dbchoice%!"
 
 echo.
@@ -113,7 +116,10 @@ if %count%==0 (
     pause
     goto :mainMenu
 )
-set /p dbchoice="Selecciona una base de datos: "
+set /p dbchoice="Selecciona una base de datos [por defecto: %DEFAULT_DB%]: "
+if "%dbchoice%"=="" (
+    set dbname=%DEFAULT_DB%
+) 
 set "DATABASE=!db%dbchoice%!"
 
 echo.

--- a/shell_postgres/shell_console/export_script.bat
+++ b/shell_postgres/shell_console/export_script.bat
@@ -2,10 +2,15 @@
 setlocal enabledelayedexpansion
 
 REM Configuración
-set PGUSER=postgres
+set DEFAULT_USER=postgres
 set PGHOST=localhost
 set PGPORT=5432
 set DEFAULT_DB=mi_financiera_demo
+set EXPORT_DIR=C:\exports
+
+REM Obtener la fecha y hora en formato AAAAMMDD_HHMM
+for /f "tokens=2 delims==" %%i in ('"wmic os get localdatetime /value"') do set datetime=%%i
+set "EXPORT_DATE=%datetime:~0,4%%datetime:~4,2%%datetime:~6,2%_%datetime:~8,2%%datetime:~10,2%"
 
 :mainMenu
 cls
@@ -18,6 +23,76 @@ echo 0. Salir
 echo ****************************************
 set /p choice="Selecciona una opcion: "
 
-if "%choice%"=="1" call backup_database.bat
-if "%choice%"=="2" call restore_database.bat
+if "%choice%"=="1" goto export_txt
+if "%choice%"=="2" goto expot_csv
 if "%choice%"=="0" goto :exitProgram
+
+:export_txt
+cls
+echo ****************************************
+echo *           Exportar TXT               *
+echo ****************************************
+echo Listando bases de datos disponibles...
+echo.
+psql -U %DEFAULT_USER% -h %PGHOST% -p %PGPORT% -t -c "SELECT datname FROM pg_database WHERE datistemplate = false;" > temp_dbs.txt
+set count=0
+for /f "usebackq tokens=* delims=" %%a in ("temp_dbs.txt") do (
+    set "dbName=%%a"
+    for /f "tokens=* delims= " %%b in ("!dbName!") do (
+        if not "%%b"=="" (
+            set /a count+=1
+            echo !count!. %%b
+            set "db!count!=%%b"
+        )
+    )
+)
+del temp_dbs.txt
+if %count%==0 (
+    echo No hay bases de datos disponibles.
+    pause
+    goto :mainMenu
+)
+set /p dbchoice="Selecciona una base de datos: "
+set "DATABASE=!db%dbchoice%!"
+echo.
+
+echo Listando tablas disponibles en la base de datos %DATABASE%...
+psql -U %DEFAULT_USER% -h %PGHOST% -p %PGPORT% -d !DATABASE! -t -c "SELECT tablename FROM pg_tables WHERE schemaname='public';" > temp_tables.txt
+
+set count=0
+for /f "usebackq tokens=* delims=" %%a in ("temp_tables.txt") do (
+    set "tableName=%%a"
+    for /f "tokens=* delims= " %%b in ("!tableName!") do (
+        if not "%%b"=="" (
+            set /a count+=1
+            echo !count!. %%b
+            set "table!count!=public.%%b"
+        )
+    )
+)
+del temp_tables.txt
+if %count%==0 (
+    echo No hay tablas disponibles.
+    pause
+    goto :mainMenu
+)
+set /p tablechoice="Selecciona la tabla a exportar: "
+set "TABLE=!table%tablechoice%!"
+
+REM Crear directorio si no existe
+if not exist "%EXPORT_DIR%" (
+    mkdir "%EXPORT_DIR%"
+)
+
+set "EXPORT_FILE=%EXPORT_DIR%\!DATABASE!_export_%EXPORT_DATE%.txt"
+
+
+psql -U %DEFAULT_USER% -d !DATABASE! -c "COPY %TABLE% TO STDOUT WITH (FORMAT CSV, HEADER true, DELIMITER ',')" > %EXPORT_FILE%
+
+pause
+goto :mainMenu
+
+:exitPrograme
+echo Saliendo del programa...
+endlocal
+exit /b

--- a/shell_postgres/shell_console/main_menu.bat
+++ b/shell_postgres/shell_console/main_menu.bat
@@ -27,7 +27,8 @@ echo 4. Borrar una base de datos
 echo 5. Crear usuario y asignar permisos
 echo 6. Modificar permisos de usuario
 echo 7. Ver usuarios y sus privilegios
-echo 8. Salir
+echo 8. Exportar Script
+echo 0. Salir
 echo ****************************************
 set /p choice="Selecciona una opcion (1/2/3/4/5/6/7/8): "
 
@@ -38,7 +39,8 @@ if "%choice%"=="4" call delete_database.bat
 if "%choice%"=="5" call create_user.bat
 if "%choice%"=="6" call modify_permissions.bat
 if "%choice%"=="7" call view_users.bat
-if "%choice%"=="8" goto :exitProgram
+if "%choice%"=="8" call export_script.bat
+if "%choice%"=="0" goto :exitProgram
 
 
 pause

--- a/shell_postgres/shell_console/main_menu.bat
+++ b/shell_postgres/shell_console/main_menu.bat
@@ -1,4 +1,5 @@
 @echo off
+chcp 65001 >nul
 setlocal enabledelayedexpansion
 
 REM ===========================================================

--- a/shell_postgres/shell_console/modify_permissions.bat
+++ b/shell_postgres/shell_console/modify_permissions.bat
@@ -1,4 +1,5 @@
 @echo off
+chcp 65001 >nul
 setlocal enabledelayedexpansion
 
 REM Configuración

--- a/shell_postgres/shell_console/restore_database.bat
+++ b/shell_postgres/shell_console/restore_database.bat
@@ -1,4 +1,5 @@
 @echo off
+chcp 65001 >nul
 setlocal enabledelayedexpansion
 
 REM Configuración

--- a/shell_postgres/shell_console/view_users.bat
+++ b/shell_postgres/shell_console/view_users.bat
@@ -1,4 +1,5 @@
 @echo off
+chcp 65001 >nul
 setlocal enabledelayedexpansion
 
 REM ===========================================================


### PR DESCRIPTION
This pull request introduces a new feature to the `shell_postgres` console: the ability to export database scripts. Changes include adding a dedicated script for exporting and integrating the feature into the main menu.

### New Feature: Export Database Scripts

* [`shell_postgres/shell_console/export_script.bat`](diffhunk://#diff-3c7d45e84494c08df948201e793181d5b00f589e4a8366dc1d1d4a1713dfb228R1-R23): Added a new script for exporting database scripts with options for TXT and CSV formats. The script includes configuration settings and a menu for user interaction.

### Integration into Main Menu

* [`shell_postgres/shell_console/main_menu.bat`](diffhunk://#diff-2bf4568faa32ed0904cada6f0f3a7fdaad29e6d5ce0c7b21de37a58ac0a6793bL30-R31): Updated the main menu to include the new "Exportar Script" option (option 8) and adjusted the exit option to be labeled as 0.
* [`shell_postgres/shell_console/main_menu.bat`](diffhunk://#diff-2bf4568faa32ed0904cada6f0f3a7fdaad29e6d5ce0c7b21de37a58ac0a6793bL41-R43): Modified the logic to call the new `export_script.bat` when option 8 is selected.